### PR TITLE
Base image for kubernetes v1.19.4

### DIFF
--- a/variables.json
+++ b/variables.json
@@ -1,14 +1,14 @@
 {
   "containerd_version": "1.2.10-3",
   "docker_version": "5:18.09.9~3-0~ubuntu-bionic",
-  "kubelet_version": "1.18.10-00",
-  "kubeadm_version": "1.19.3-00",
-  "kubectl_version": "1.19.3-00",
+  "kubelet_version": "1.19.4-00",
+  "kubeadm_version": "1.19.4-00",
+  "kubectl_version": "1.19.4-00",
 
   "disk_size": "20480",
 
-  "source_iso_url": "https://cloud-images.ubuntu.com/releases/bionic/release-20201031/ubuntu-18.04-server-cloudimg-amd64.img",
-  "source_iso_checksum": "5f7fea2bfd9f0471eb70b47fdabe9c60dc71440172588f0aa68a1d29a636b11e",
+  "source_iso_url": "https://cloud-images.ubuntu.com/releases/bionic/release-20201112/ubuntu-18.04-server-cloudimg-amd64.img",
+  "source_iso_checksum": "a85c3190d0bbb4989c078b18c87ec3c7585baea12e430ef6c5bebf63e5998ec2",
 
   "output_vm_name": "baseos.qcow2",
 


### PR DESCRIPTION
**What this PR does / why we need it:**
as the title indicates, this PR create a base image for kubernetes v1.19.4
**Which issue this PR fixes (use the format fixes #<issue number>(, fixes #<issue_number>, ...) to automatically close the issue when PR gets merged):** fixes #25 