### PR TITLE
Bump base image and containerd

### DIFF
--- a/variables.json
+++ b/variables.json
@@ -1,5 +1,5 @@
 {
-  "containerd_version": "1.2.10-3",
+  "containerd_version": "1.3.9-1",
   "docker_version": "5:19.03.13~3-0~ubuntu-bionic",
   "kubelet_version": "1.18.12-00",
   "kubeadm_version": "1.19.4-00",
@@ -7,8 +7,8 @@
 
   "disk_size": "20480",
 
-  "source_iso_url": "https://cloud-images.ubuntu.com/releases/bionic/release-20201031/ubuntu-18.04-server-cloudimg-amd64.img",
-  "source_iso_checksum": "5f7fea2bfd9f0471eb70b47fdabe9c60dc71440172588f0aa68a1d29a636b11e",
+  "source_iso_url": "https://cloud-images.ubuntu.com/releases/bionic/release-20201125/ubuntu-18.04-server-cloudimg-amd64.img",
+  "source_iso_checksum": "04a92109979df63aa56e749b9e607a404c980460edd5b3f69f97c405f0388554",
 
   "output_vm_name": "baseos.qcow2",
 


### PR DESCRIPTION
I have only built a new image but not tested it yet.

edit: 

```
❯ ./bin/ck8s ops kubectl sc version --short
Client Version: v1.17.11
Server Version: v1.18.12

❯ ./bin/ck8s ops kubectl sc get pods -A
NAMESPACE     NAME                                                        READY   STATUS    RESTARTS   AGE
kube-system   calico-kube-controllers-59877c7fb4-fgt8z                    1/1     Running   0          11m
kube-system   calico-node-9zjtn                                           1/1     Running   0          7m54s
kube-system   calico-node-d4nxv                                           1/1     Running   0          10m
kube-system   calico-node-r2kst                                           1/1     Running   0          11m
kube-system   coredns-6f5c7bbdfb-2g5mr                                    1/1     Running   0          11m
kube-system   coredns-6f5c7bbdfb-c4jxg                                    1/1     Running   0          11m
kube-system   etcd-olle-dev-service-cluster-master-0                      1/1     Running   0          10m
kube-system   kube-apiserver-olle-dev-service-cluster-master-0            1/1     Running   0          10m
kube-system   kube-controller-manager-olle-dev-service-cluster-master-0   1/1     Running   0          10m
kube-system   kube-proxy-66jz9                                            1/1     Running   0          10m
kube-system   kube-proxy-sj7ck                                            1/1     Running   0          11m
kube-system   kube-proxy-szm76                                            1/1     Running   0          7m54s
kube-system   kube-scheduler-olle-dev-service-cluster-master-0            1/1     Running   0          10m

# From one of the worker nodes
ubuntu@olle-dev-service-cluster-worker-0:~$ containerd --version
containerd containerd.io 1.3.9 ea765aba0d05254012b0b9e595e995c09186427f

ubuntu@olle-dev-service-cluster-worker-0:~$ docker --version
Docker version 19.03.14, build 5eb3275d40
```